### PR TITLE
Setting up GitHub CI for packages

### DIFF
--- a/.github/workflows/node-production.yml
+++ b/.github/workflows/node-production.yml
@@ -1,0 +1,175 @@
+name: Node Packages – Production Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  id-token: write      # for provenance / npm‑pkg OIDC
+  packages: write
+
+env:
+  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+jobs:
+  build-and-publish:
+    name: Build & publish ${{ matrix.package }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: core                 # 1
+            node: 16.15.1
+          - package: common               # 2
+            node: 16.13.1
+          - package: fortmatic            # 3
+            node: 16.13.1
+          - package: gnosis               # 4
+            node: 16.13.1
+          - package: injected             # 5
+            node: 16.13.1
+          - package: frame                # 6
+            node: 16.13.1
+          - package: keepkey              # 7
+            node: 16.20.2
+          - package: keystone             # 8
+            node: 18.0.0
+          - package: ledger               # 9
+            node: 18.0.0
+          - package: mew                  # 10
+            node: 16.13.1
+          - package: mew-wallet           # 11
+            node: 16.13.1
+          - package: portis               # 12
+            node: 16.13.1
+          - package: torus                # 13
+            node: 16.18.1
+          - package: trezor               # 14
+            node: 20.18.0
+          - package: trust                # 15
+            node: 16.13.1
+          - package: okx                  # 16
+            node: 16.13.1
+          - package: frontier             # 17
+            node: 16.13.1
+          - package: walletconnect        # 18
+            node: 18.0.0
+          - package: walletlink           # 19
+            node: 16.13.1
+          - package: react                # 20
+            node: 16.15.1
+          - package: magic                # 21
+            node: 16.13.1
+          - package: coinbase             # 22
+            node: 16.13.1
+          - package: web3auth             # 23
+            node: 18.0.0
+          - package: dcent                # 24
+            node: 16.13.1
+          - package: vue                  # 25
+            node: 16.15.1
+          - package: gas                  # 26
+            node: 16.13.1
+          - package: hw-common            # 27
+            node: 16.13.1
+          - package: sequence             # 28
+            node: 16.13.1
+          - package: tallyho              # 29
+            node: 16.13.1
+          - package: enkrypt              # 30
+            node: 16.13.1
+          - package: uauth                # 31
+            node: 18.0.0
+          - package: transaction-preview  # 32
+            node: 16.13.1
+          - package: zeal                 # 33
+            node: 16.13.1
+          - package: phantom              # 34
+            node: 16.13.1
+          - package: xdefi                # 35
+            node: 16.13.1
+          - package: infinity-wallet      # 36
+            node: 16.13.1
+          - package: taho                 # 37
+            node: 16.13.1
+          - package: unstoppable-resolution  # 38
+            node: 16.13.1
+          - package: cede-store           # 39
+            node: 16.13.1
+          - package: arcana-auth          # 40
+            node: 18.0.0
+          - package: blocto               # 41
+            node: 16.13.1
+          - package: venly                # 42
+            node: 18.18.2
+          - package: bitget               # 43
+            node: 16.13.1
+          - package: bitkeep              # 44
+            node: 16.13.1
+          - package: metamask             # 45
+            node: 18.18.2
+          - package: solid                # 46
+            node: 16.15.1
+          - package: para                 # 47
+            node: 18.18.2
+          - package: particle-network     # 48
+            node: 18.0.0
+          - package: finoaconnect         # 49
+            node: 18.0.0
+          - package: wagmi                # 50
+            node: 18.0.0
+          - package: passport             # 51
+            node: 18.0.0
+          - package: bloom                # 52
+            node: 18.0.0
+          - package: keplr                # 53
+            node: 18.0.0
+
+    defaults:
+      run:
+        shell: bash
+        working-directory: packages/${{ matrix.package }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node ${{ matrix.node }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          registry-url: https://registry.npmjs.org/
+
+      # ────── skip alpha versions ──────
+      - id: version
+        run: echo "v=$(node -p 'require(\"./package.json\").version')" >> "$GITHUB_OUTPUT"
+
+      - name: Skip alpha builds on main
+        if: contains(steps.version.outputs.v, '-alpha')
+        run: echo "Alpha version detected – skipping publish."
+      # ─────────────────────────────────
+
+      - name: Cache Yarn
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/yarn
+            node_modules
+          key: ${{ runner.os }}-${{ matrix.node }}-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Generate workspace lock‑file
+        run: yarn generate-lock-entry >> yarn.lock
+
+      - name: Install dependencies
+        run: yarn --immutable
+
+      - name: Type‑check & build
+        run: |
+          yarn type-check
+          yarn build
+
+      - name: Publish to npm (latest)
+        if: ${{ !contains(steps.version.outputs.v, '-alpha') }}
+        run: npm publish --access public

--- a/.github/workflows/node-staging.yml
+++ b/.github/workflows/node-staging.yml
@@ -1,0 +1,175 @@
+name: Node Packages – Staging (Alpha ➜ next)
+
+on:
+  push:
+    branches: [develop]
+
+permissions:
+  contents: read
+  id-token: write
+  packages: write
+
+env:
+  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+jobs:
+  build-and-publish:
+    name: Build & publish alpha ${{ matrix.package }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: core
+            node: 16.15.1
+          - package: common
+            node: 16.13.1
+          - package: fortmatic
+            node: 16.13.1
+          - package: gnosis
+            node: 16.13.1
+          - package: injected
+            node: 16.13.1
+          - package: frame
+            node: 16.13.1
+          - package: keepkey
+            node: 16.20.2
+          - package: keystone
+            node: 18.0.0
+          - package: ledger
+            node: 18.0.0
+          - package: mew
+            node: 16.13.1
+          - package: mew-wallet
+            node: 16.13.1
+          - package: portis
+            node: 16.13.1
+          - package: torus
+            node: 16.18.1
+          - package: trezor
+            node: 20.18.0
+          - package: trust
+            node: 16.13.1
+          - package: okx
+            node: 16.13.1
+          - package: frontier
+            node: 16.13.1
+          - package: walletconnect
+            node: 18.0.0
+          - package: walletlink
+            node: 16.13.1
+          - package: react
+            node: 16.15.1
+          - package: magic
+            node: 16.13.1
+          - package: coinbase
+            node: 16.13.1
+          - package: web3auth
+            node: 18.0.0
+          - package: dcent
+            node: 16.13.1
+          - package: vue
+            node: 16.15.1
+          - package: gas
+            node: 16.13.1
+          - package: hw-common
+            node: 16.13.1
+          - package: sequence
+            node: 16.13.1
+          - package: tallyho
+            node: 16.13.1
+          - package: enkrypt
+            node: 16.13.1
+          - package: uauth
+            node: 18.0.0
+          - package: transaction-preview
+            node: 16.13.1
+          - package: zeal
+            node: 16.13.1
+          - package: phantom
+            node: 16.13.1
+          - package: xdefi
+            node: 16.13.1
+          - package: infinity-wallet
+            node: 16.13.1
+          - package: taho
+            node: 16.13.1
+          - package: unstoppable-resolution
+            node: 16.13.1
+          - package: cede-store
+            node: 16.13.1
+          - package: arcana-auth
+            node: 18.0.0
+          - package: blocto
+            node: 16.13.1
+          - package: venly
+            node: 18.18.2
+          - package: bitget
+            node: 16.13.1
+          - package: bitkeep
+            node: 16.13.1
+          - package: metamask
+            node: 18.18.2
+          - package: solid
+            node: 16.15.1
+          - package: para
+            node: 18.18.2
+          - package: particle-network
+            node: 18.0.0
+          - package: finoaconnect
+            node: 18.0.0
+          - package: wagmi
+            node: 18.0.0
+          - package: passport
+            node: 18.0.0
+          - package: bloom
+            node: 18.0.0
+          - package: keplr
+            node: 18.0.0
+
+    defaults:
+      run:
+        shell: bash
+        working-directory: packages/${{ matrix.package }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node ${{ matrix.node }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          registry-url: https://registry.npmjs.org/
+
+      # ────── only publish *alpha* versions ──────
+      - id: version
+        run: echo "v=$(node -p 'require(\"./package.json\").version')" >> "$GITHUB_OUTPUT"
+
+      - name: Skip non‑alpha builds on develop
+        if: ${{ !contains(steps.version.outputs.v, '-alpha') }}
+        run: echo "Not an alpha – skipping publish."
+      # ───────────────────────────────────────────
+
+      - name: Cache Yarn
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/yarn
+            node_modules
+          key: ${{ runner.os }}-${{ matrix.node }}-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Generate workspace lock‑file
+        run: yarn generate-lock-entry >> yarn.lock
+
+      - name: Install dependencies
+        run: yarn --immutable
+
+      - name: Type‑check & build
+        run: |
+          yarn type-check
+          yarn build
+
+      - name: Publish to npm (next)
+        if: contains(steps.version.outputs.v, '-alpha')
+        run: npm publish --tag next --access public


### PR DESCRIPTION
This pull request introduces two new GitHub Actions workflows to automate the release process for Node.js packages. One workflow handles production releases for the `main` branch, while the other manages staging (alpha) releases for the `develop` branch. These workflows streamline the build, test, and publish processes for multiple packages with specific Node.js versions.

### New GitHub Actions Workflows

#### Production Workflow:
* Added `.github/workflows/node-production.yml` to handle production releases triggered by pushes to the `main` branch. The workflow builds and publishes packages to npm with the `latest` tag, skipping alpha versions.

#### Staging Workflow:
* Added `.github/workflows/node-staging.yml` to handle staging releases triggered by pushes to the `develop` branch. The workflow builds and publishes alpha versions of packages to npm with the `next` tag, skipping non-alpha versions.