### PR TITLE
Pin github ci version

### DIFF
--- a/.github/workflows/node-production.yml
+++ b/.github/workflows/node-production.yml
@@ -134,10 +134,10 @@ jobs:
         working-directory: packages/${{ matrix.package }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Use Node ${{ matrix.node }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node }}
           registry-url: https://registry.npmjs.org/
@@ -152,7 +152,7 @@ jobs:
       # ─────────────────────────────────
 
       - name: Cache Yarn
-        uses: actions/cache@v3
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |
             ~/.cache/yarn

--- a/.github/workflows/node-staging.yml
+++ b/.github/workflows/node-staging.yml
@@ -134,10 +134,10 @@ jobs:
         working-directory: packages/${{ matrix.package }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Use Node ${{ matrix.node }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node }}
           registry-url: https://registry.npmjs.org/
@@ -152,7 +152,7 @@ jobs:
       # ───────────────────────────────────────────
 
       - name: Cache Yarn
-        uses: actions/cache@v3
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |
             ~/.cache/yarn


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for both production and staging environments to use specific commit SHAs for action versions, ensuring stability and reproducibility. The changes affect the `checkout`, `setup-node`, and `cache` actions.

### Workflow updates:

* `.github/workflows/node-production.yml`:
  - Updated `actions/checkout` to use commit SHA `11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2).
  - Updated `actions/setup-node` to use commit SHA `49933ea5288caeca8642d1e84afbd3f7d6820020` (v4.4.0).
  - Updated `actions/cache` to use commit SHA `5a3ec84eff668545956fd18022155c47e93e2684` (v4.2.3).

* `.github/workflows/node-staging.yml`:
  - Updated `actions/checkout` to use commit SHA `11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2).
  - Updated `actions/setup-node` to use commit SHA `49933ea5288caeca8642d1e84afbd3f7d6820020` (v4.4.0).
  - Updated `actions/cache` to use commit SHA `5a3ec84eff668545956fd18022155c47e93e2684` (v4.2.3).